### PR TITLE
ログイン情報保存機能を実装

### DIFF
--- a/sample/demo/base/app/src/main/java/jp/co/omron/plus_sensing/hvc_c2w_sample/MainActivity.java
+++ b/sample/demo/base/app/src/main/java/jp/co/omron/plus_sensing/hvc_c2w_sample/MainActivity.java
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.SharedPreferences;
 import android.media.AudioFormat;
 import android.media.AudioManager;
 import android.media.AudioTrack;
@@ -12,6 +13,7 @@ import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
 import android.os.AsyncTask;
 import android.os.Handler;
+import android.preference.PreferenceManager;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.text.InputType;
@@ -20,6 +22,7 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.Adapter;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.CheckBox;
@@ -154,6 +157,63 @@ public class MainActivity extends AppCompatActivity {
 
         //noinspection SimplifiableIfStatement
         if (id == R.id.action_settings) {
+            return true;
+        }
+
+        if (id == R.id.save_account) {
+            SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(this);
+            SharedPreferences.Editor edit = pref.edit();
+
+            String email = ((EditText)findViewById(R.id.editText)).getText().toString();
+            String passwd = ((EditText)findViewById(R.id.editText2)).getText().toString();
+
+            // 本来は定数化すべき
+            edit.putString("login_id", email);
+            edit.putString("login_pass", passwd);
+            edit.commit();
+
+            return true;
+        }
+
+        if (id == R.id.load_account) {
+            SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(this);
+            String email = pref.getString("login_id", "");
+            String passwd = pref.getString("login_pass", "");
+
+            ((EditText)findViewById(R.id.editText)).setText(email);
+            ((EditText)findViewById(R.id.editText2)).setText(passwd);
+            return true;
+        }
+
+        if (id == R.id.save_network) {
+            SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(this);
+            SharedPreferences.Editor edit = pref.edit();
+
+            String ssid = (String)((Spinner)findViewById(R.id.spinner)).getSelectedItem();
+            String passwd = ((EditText)findViewById(R.id.editText3)).getText().toString();
+
+            // 本来は定数化すべき
+            edit.putString("network_ssid", ssid);
+            edit.putString("network_pass", passwd);
+            edit.commit();
+
+            return true;
+        }
+
+        if (id == R.id.load_network) {
+            SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(this);
+            String ssid = pref.getString("network_ssid", "");
+            String passwd = pref.getString("network_pass", "");
+
+            Spinner ssidSpinner = (Spinner)findViewById(R.id.spinner);
+            Adapter adapter = ssidSpinner.getAdapter();
+            for (int i = 0; i < adapter.getCount(); i++) {
+                if (adapter.getItem(i).equals(ssid)) {
+                    ssidSpinner.setSelection(i);
+                    break;
+                }
+            }
+            ((EditText)findViewById(R.id.editText3)).setText(passwd);
             return true;
         }
 

--- a/sample/demo/base/app/src/main/res/menu/menu_main.xml
+++ b/sample/demo/base/app/src/main/res/menu/menu_main.xml
@@ -3,4 +3,12 @@
     xmlns:tools="http://schemas.android.com/tools" tools:context=".MainActivity">
     <item android:id="@+id/action_settings" android:title="@string/action_settings"
         android:orderInCategory="100" app:showAsAction="never" />
+    <item android:id="@+id/save_account" android:title="@string/save_account"
+        android:orderInCategory="100" app:showAsAction="never" />
+    <item android:id="@+id/load_account" android:title="@string/load_account"
+        android:orderInCategory="100" app:showAsAction="never" />
+    <item android:id="@+id/save_network" android:title="@string/save_network"
+        android:orderInCategory="100" app:showAsAction="never" />
+    <item android:id="@+id/load_network" android:title="@string/load_network"
+        android:orderInCategory="100" app:showAsAction="never" />
 </menu>

--- a/sample/demo/base/app/src/main/res/values/strings.xml
+++ b/sample/demo/base/app/src/main/res/values/strings.xml
@@ -3,4 +3,15 @@
 
     <string name="hello_world">Hello world!</string>
     <string name="action_settings">Settings</string>
+    <string name="save_account">Save Account</string>
+    <string name="load_account">Load Account</string>
+    <string name="save_network">Save Network</string>
+    <string name="load_network">Load Network</string>
+
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
+
+    <string name="entry1">Entry1</string>
+    <string name="entry2">Entry2</string>
+    <string name="key_list_preference">KeyListPreference</string>
 </resources>


### PR DESCRIPTION
ハッカソンのイベントなどでSDKを利用して開発を行う場合、提供されているサンプルに対して修正を加えながら使い方を調べたり、機能を実装したりします。
その際に毎回アカウント情報、ネットワーク情報を入力しないければならないのは非常に手間です。
オプションメニューより、サービスログインアカウントとネットワーク情報の保存、取得を行えるようにすることでこの手間を省けるようにしました。